### PR TITLE
commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+permissions:
+  packages: read
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: echo -e "\n//npm.pkg.github.com/:_authToken-${{ secrets.GITHUB_TOKEN }}" >> ./.npmrc
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm install
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+        with:
+          static_site_generator: next
+
+      - name: Build with Next.js
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./out
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ The website is being hosted on [https://jessicafealy.dev](https://jessicafealy.d
   npm install
   npm run dev
 ```
+
+## Deployment
+
+Concurrent deployments to both github pages and Azure static apps:
+
+Github Pages: [https://jessicafealy.dev]("https://jessicafealy.dev")
+Azure Static Pages: [https://www.jessicafealy.dev]("https://www.jessicafealy.dev")


### PR DESCRIPTION
Reason behind this decision, Azure was unable to communicate nicely with GoDaddy for the handling of the base domain jessicafealy.dev. The lack of a registered endpoint for this wasn't pretty. 

Solutions is to use Azure Front Door to handle the redirect, but I don't see the necessity to pay for that service. Will look for alternative services. 

Github Pages proved unreliable with browsers frequently finding a non existing page where other browsers worked fine